### PR TITLE
Improve help text.

### DIFF
--- a/src/Seq.App.HttpRequest/HttpApp.cs
+++ b/src/Seq.App.HttpRequest/HttpApp.cs
@@ -45,7 +45,7 @@ namespace Seq.App.HttpRequest
         public bool BodyIsTemplate { get; set; }
 
         [SeqAppSetting(IsOptional = true, DisplayName = "Media Type",
-            HelpText = "Media type describing the body.")]
+            HelpText = "Media type describing the body. Required if a body is specified.")]
         public string? MediaType { get; set; }
         
         [SeqAppSetting(InputType = SettingInputType.Password, IsOptional = true, DisplayName = "Authentication Header",

--- a/src/Seq.App.HttpRequest/HttpApp.cs
+++ b/src/Seq.App.HttpRequest/HttpApp.cs
@@ -45,7 +45,7 @@ namespace Seq.App.HttpRequest
         public bool BodyIsTemplate { get; set; }
 
         [SeqAppSetting(IsOptional = true, DisplayName = "Media Type",
-            HelpText = "Media type describing the body. Required if a body is specified.")]
+            HelpText = "Media type describing the body. Required if a `Body` is specified.")]
         public string? MediaType { get; set; }
         
         [SeqAppSetting(InputType = SettingInputType.Password, IsOptional = true, DisplayName = "Authentication Header",


### PR DESCRIPTION
Change the `Media Type` help text to indicate that media type is required if the request has a body. 